### PR TITLE
Update versions of Checkstyle and Jersey

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -143,19 +143,13 @@
         </contributor>
         <contributor>
             <name>Stepan Kopriva</name>
-            <organization>Oracle Corporation</organization>
-            <organizationUrl>http://www.oracle.com</organizationUrl>
         </contributor>
         <contributor>
             <name>Danny Coward</name>
-            <organization>Oracle Corporation</organization>
-            <organizationUrl>http://www.oracle.com</organizationUrl>
         </contributor>
         <contributor>
             <name>Jitendra Kotamraju</name>
             <url>https://www.java.net/blogs/jitu</url>
-            <organization>Oracle Corporation</organization>
-            <organizationUrl>http://www.oracle.com</organizationUrl>
         </contributor>
     </contributors>
 
@@ -254,7 +248,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-checkstyle-plugin</artifactId>
-                <version>2.14</version>
+                <version>2.15</version>
                 <executions>
                     <execution>
                         <phase>validate</phase>
@@ -274,7 +268,7 @@
                     <dependency>
                         <groupId>com.puppycrawl.tools</groupId>
                         <artifactId>checkstyle</artifactId>
-                        <version>6.3</version>
+                        <version>6.8.1</version>
                         <exclusions>
                             <!-- MCHECKSTYLE-156 -->
                             <exclusion>

--- a/samples/shared-collection/pom.xml
+++ b/samples/shared-collection/pom.xml
@@ -77,7 +77,7 @@
         <dependency>
             <groupId>org.glassfish.jersey.media</groupId>
             <artifactId>jersey-media-sse</artifactId>
-            <version>2.16</version>
+            <version>2.19</version>
             <scope>provided</scope>
         </dependency>
 


### PR DESCRIPTION
Updated Checkstyle (6.3 -> 6.8.1)
Updated Jersey (2.16 -> 2.19).

Removed organization for contributors that don't work at Oracle anymore.