### PR TITLE
Fixed shared transport assignment

### DIFF
--- a/containers/grizzly-client/src/main/java/org/glassfish/tyrus/container/grizzly/client/GrizzlyClientSocket.java
+++ b/containers/grizzly-client/src/main/java/org/glassfish/tyrus/container/grizzly/client/GrizzlyClientSocket.java
@@ -302,7 +302,7 @@ public class GrizzlyClientSocket {
 
         try {
             if (sharedTransport) {
-                privateTransport = getOrCreateSharedTransport(workerThreadPoolConfig, selectorThreadPoolConfig);
+                transport = getOrCreateSharedTransport(workerThreadPoolConfig, selectorThreadPoolConfig);
             }
         } catch (IOException e) {
             LOGGER.log(Level.SEVERE, "Transport failed to start.", e);


### PR DESCRIPTION
Looks like a typo to me. 

The original problem I had was when I was using shared container and the websocket server restarted, then the client couldn't reconnect (read more [here](http://stackoverflow.com/questions/31757377/tyrus-client-cannot-reconnect-on-server-restart-when-client-shared-container-is)).

I think the issue is due to the fact that the share transport is assigned to `privateTransport` by mistake. Then when an exception happens privateTransport which is pointing to shared transport will be closed "incorrectly". This will somehow cause the selector runners to die. The problem is that I guess since the shared transport is not set to null it cannot be recreated. So the transport gets into a BAD state.

This fix solved my problem. 